### PR TITLE
chore: fix clippy lints, ranking bug, dead code, and locale handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Desktop entry names, descriptions, and keywords now honor the system locale instead of always using English
+
+### Fixed
+- Recently launched apps now surface in the initial list even when they sort outside the first `initial_results` alphabetically
+- Launching yeet while a window is already open no longer stacks a second window inside the first instance
+
+### Removed
+- `general.monitor` config option — it was never wired up (yeet opens on the active monitor); existing configs with the key still parse
+
 ## [0.1.4] - 2026-02-22
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Config lives in `~/.config/yeet/`. Yeet ships with sensible defaults — only ov
 
 ```toml
 [general]
-monitor = 0           # Show on specific monitor (0 = primary)
 max_results = 8       # Max results when searching
 initial_results = 8   # Results shown before typing (0 = just search bar)
 terminal = "alacritty"

--- a/defaults/config.toml
+++ b/defaults/config.toml
@@ -2,9 +2,6 @@
 # User overrides go in ~/.config/yeet/config.toml
 
 [general]
-# Show window on specific monitor (0 = primary)
-monitor = 0
-
 # Max results to show when searching
 max_results = 8
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,8 +17,6 @@ pub struct Config {
 
 #[derive(Debug, Deserialize)]
 pub struct GeneralConfig {
-    #[serde(default)]
-    pub monitor: u32,
     #[serde(default = "default_max_results")]
     pub max_results: usize,
     #[serde(default = "default_initial_results")]
@@ -106,7 +104,6 @@ fn default_true() -> bool {
 impl Default for GeneralConfig {
     fn default() -> Self {
         Self {
-            monitor: 0,
             max_results: default_max_results(),
             initial_results: default_initial_results(),
             terminal: default_terminal(),

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -1,5 +1,6 @@
 use crate::config::{Config, CustomApp};
-use freedesktop_desktop_entry::{DesktopEntry, Iter as DesktopIter};
+use freedesktop_desktop_entry::{get_languages_from_env, DesktopEntry, Iter as DesktopIter};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
@@ -12,11 +13,11 @@ enum LaunchCommand {
 #[derive(Debug, Clone)]
 pub struct App {
     pub name: String,
-    pub exec: String,
     pub icon: Option<String>,
     pub description: Option<String>,
     pub keywords: Vec<String>,
     pub terminal: bool,
+    pub favorite: bool,
     launch: LaunchCommand,
 }
 
@@ -24,46 +25,48 @@ impl App {
     fn from_custom(custom: &CustomApp) -> Self {
         Self {
             name: custom.name.clone(),
-            exec: custom.exec.clone(),
             icon: custom.icon.clone(),
             description: None,
             keywords: custom.keywords.clone(),
             terminal: false,
+            favorite: false,
             launch: LaunchCommand::Shell(custom.exec.clone()),
         }
     }
 
-    pub fn search_text(&self) -> String {
-        let mut text = self.name.clone();
-        if let Some(desc) = &self.description {
-            text.push(' ');
-            text.push_str(desc);
+    /// A bare item with a name only; used in tests.
+    #[cfg(test)]
+    pub fn plain(name: String) -> Self {
+        Self {
+            launch: LaunchCommand::Shell(name.clone()),
+            name,
+            icon: None,
+            description: None,
+            keywords: Vec::new(),
+            terminal: false,
+            favorite: false,
         }
-        for kw in &self.keywords {
-            text.push(' ');
-            text.push_str(kw);
-        }
-        text
     }
 }
 
 pub fn discover_apps(config: &Config) -> Vec<App> {
     let mut apps = Vec::new();
-    let exclude_set: std::collections::HashSet<&str> =
-        config.apps.exclude.iter().map(|s| s.as_str()).collect();
+    let exclude_set: HashSet<&str> = config.apps.exclude.iter().map(|s| s.as_str()).collect();
 
     let all_dirs: Vec<PathBuf> = xdg_application_dirs()
         .into_iter()
         .chain(config.apps.extra_dirs.iter().cloned())
         .collect();
 
+    let locales = get_languages_from_env();
+
     for path in DesktopIter::new(all_dirs.into_iter()) {
-        if let Ok(entry) = DesktopEntry::from_path(&path, Some(&["en"])) {
+        if let Ok(entry) = DesktopEntry::from_path(&path, Some(&locales)) {
             if entry.no_display() || entry.hidden() {
                 continue;
             }
 
-            let Some(name) = entry.name(&["en"]) else {
+            let Some(name) = entry.name(&locales) else {
                 continue;
             };
             let exec_args = match entry.parse_exec() {
@@ -75,20 +78,18 @@ pub fn discover_apps(config: &Config) -> Vec<App> {
                 continue;
             }
 
-            let app = App {
+            apps.push(App {
                 name: name.to_string(),
-                exec: exec_args.join(" "),
                 icon: entry.icon().map(|s| s.to_string()),
-                description: entry.comment(&["en"]).map(|s| s.to_string()),
+                description: entry.comment(&locales).map(|s| s.to_string()),
                 keywords: entry
-                    .keywords(&["en"])
+                    .keywords(&locales)
                     .map(|kws| kws.into_iter().map(|s| s.to_string()).collect())
                     .unwrap_or_default(),
                 terminal: entry.terminal(),
+                favorite: false,
                 launch: LaunchCommand::Direct(exec_args),
-            };
-
-            apps.push(app);
+            });
         }
     }
 
@@ -96,18 +97,12 @@ pub fn discover_apps(config: &Config) -> Vec<App> {
         apps.push(App::from_custom(custom));
     }
 
-    let favorites_set: std::collections::HashSet<&str> =
-        config.apps.favorites.iter().map(|s| s.as_str()).collect();
+    let favorites_set: HashSet<&str> = config.apps.favorites.iter().map(|s| s.as_str()).collect();
+    for app in &mut apps {
+        app.favorite = favorites_set.contains(app.name.as_str());
+    }
 
-    apps.sort_by(|a, b| {
-        let a_fav = favorites_set.contains(a.name.as_str());
-        let b_fav = favorites_set.contains(b.name.as_str());
-        match (a_fav, b_fav) {
-            (true, false) => std::cmp::Ordering::Less,
-            (false, true) => std::cmp::Ordering::Greater,
-            _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
-        }
-    });
+    apps.sort_by_cached_key(|a| (!a.favorite, a.name.to_lowercase()));
 
     apps
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -87,9 +87,9 @@ pub fn trim_history(max_lines: usize) {
             return Ok(());
         }
 
-        entries.sort_by(|a, b| b.0.cmp(&a.0));
+        entries.sort_by_key(|&(ts, _)| std::cmp::Reverse(ts));
         entries.truncate(max_lines);
-        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries.sort_by_key(|&(ts, _)| ts);
 
         let (temp_path, mut file) = create_temp_history_file(&path)?;
         for (ts, name) in entries {
@@ -220,9 +220,9 @@ mod tests {
 
         assert_eq!(entries.len(), 10);
 
-        entries.sort_by(|a, b| b.0.cmp(&a.0));
+        entries.sort_by_key(|&(ts, _)| std::cmp::Reverse(ts));
         entries.truncate(5);
-        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries.sort_by_key(|&(ts, _)| ts);
 
         let mut file = fs::File::create(&path).unwrap();
         for (ts, name) in &entries {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,11 @@
-#![allow(dead_code)]
-
 mod config;
 mod desktop;
-pub mod history;
+mod history;
 mod ui;
 
 use config::Config;
 use desktop::discover_apps;
+use gtk4::gio::ApplicationFlags;
 use gtk4::prelude::*;
 use gtk4::Application;
 
@@ -17,7 +16,12 @@ fn main() {
 
     let apps = discover_apps(&config);
 
-    let app = Application::builder().application_id(APP_ID).build();
+    // NON_UNIQUE: launching yeet while a window is already open gets its own
+    // instance instead of stacking a second window inside the first one.
+    let app = Application::builder()
+        .application_id(APP_ID)
+        .flags(ApplicationFlags::NON_UNIQUE)
+        .build();
 
     app.connect_activate(move |app| {
         ui::build_ui(app, &config, apps.clone());

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,6 +10,7 @@ use gtk4::{
 };
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use std::cell::RefCell;
+use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -98,17 +99,7 @@ pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>) {
 
     {
         let mut filtered = filtered_apps.borrow_mut();
-        filtered.clear();
-        for (i, _) in apps.iter().enumerate().take(initial_results) {
-            filtered.push(i);
-        }
-        if !history.is_empty() {
-            filtered.sort_by(|&a, &b| {
-                let a_ts = history.get(&apps[a].name).copied().unwrap_or(0);
-                let b_ts = history.get(&apps[b].name).copied().unwrap_or(0);
-                b_ts.cmp(&a_ts)
-            });
-        }
+        *filtered = initial_indices(&apps, &history, initial_results);
         populate_list(
             &list_box,
             &apps,
@@ -117,10 +108,7 @@ pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>) {
             show_descriptions,
         );
     }
-
-    if let Some(row) = list_box.row_at_index(0) {
-        list_box.select_row(Some(&row));
-    }
+    select_first(&list_box);
 
     {
         let apps = apps.clone();
@@ -137,19 +125,9 @@ pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>) {
             let query = query.trim();
             let query_len = query.chars().count();
             let mut filtered = filtered_apps.borrow_mut();
-            filtered.clear();
 
             if query_len == 0 {
-                for (i, _) in apps.iter().enumerate().take(initial_results) {
-                    filtered.push(i);
-                }
-                if !history.is_empty() {
-                    filtered.sort_by(|&a, &b| {
-                        let a_ts = history.get(&apps[a].name).copied().unwrap_or(0);
-                        let b_ts = history.get(&apps[b].name).copied().unwrap_or(0);
-                        b_ts.cmp(&a_ts)
-                    });
-                }
+                *filtered = initial_indices(&apps, &history, initial_results);
                 populate_list(
                     &list_box,
                     &apps,
@@ -157,11 +135,11 @@ pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>) {
                     show_shortcuts,
                     show_descriptions,
                 );
-                if let Some(row) = list_box.row_at_index(0) {
-                    list_box.select_row(Some(&row));
-                }
+                select_first(&list_box);
                 return;
             }
+
+            filtered.clear();
 
             let query_lower = query.to_lowercase();
             let has_substring_matches = query_len >= 2
@@ -222,10 +200,7 @@ pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>) {
                 show_shortcuts,
                 show_descriptions,
             );
-
-            if let Some(row) = list_box.row_at_index(0) {
-                list_box.select_row(Some(&row));
-            }
+            select_first(&list_box);
         });
     }
 
@@ -359,6 +334,22 @@ pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>) {
     window.present();
 }
 
+/// Indices shown before any query: favorites first, then most recently
+/// launched, then the pre-sorted (alphabetical) order.
+fn initial_indices(apps: &[App], history: &HashMap<String, u64>, count: usize) -> Vec<usize> {
+    let mut indices: Vec<usize> = (0..apps.len()).collect();
+    if !history.is_empty() {
+        indices.sort_by_key(|&i| {
+            (
+                !apps[i].favorite,
+                Reverse(history.get(&apps[i].name).copied().unwrap_or(0)),
+            )
+        });
+    }
+    indices.truncate(count);
+    indices
+}
+
 fn populate_list(
     list_box: &ListBox,
     apps: &[App],
@@ -429,6 +420,12 @@ fn create_app_row(app: &App, shortcut: Option<usize>, show_descriptions: bool) -
     row
 }
 
+fn select_first(list_box: &ListBox) {
+    if let Some(row) = list_box.row_at_index(0) {
+        list_box.select_row(Some(&row));
+    }
+}
+
 fn move_selection(list_box: &ListBox, delta: i32) {
     let current = list_box.selected_row().map(|r| r.index()).unwrap_or(-1);
     let new_idx = (current + delta).max(0);
@@ -454,14 +451,10 @@ fn recency_boost(history: &HashMap<String, u64>, app_name: &str, now: u64) -> i6
 fn load_css() {
     let provider = CssProvider::new();
 
-    if let Some(user_path) = Config::user_style_path() {
-        if user_path.exists() {
-            provider.load_from_path(&user_path);
-        } else {
-            provider.load_from_data(DEFAULT_STYLE);
-        }
-    } else {
-        provider.load_from_data(DEFAULT_STYLE);
+    let user_style = Config::user_style_path().filter(|p| p.exists());
+    match user_style {
+        Some(path) => provider.load_from_path(&path),
+        None => provider.load_from_data(DEFAULT_STYLE),
     }
 
     gtk4::style_context_add_provider_for_display(
@@ -469,4 +462,42 @@ fn load_css() {
         &provider,
         gtk4::STYLE_PROVIDER_PRIORITY_USER,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn plain_apps(names: &[&str]) -> Vec<App> {
+        names.iter().map(|n| App::plain(n.to_string())).collect()
+    }
+
+    #[test]
+    fn initial_indices_surfaces_recent_apps_beyond_first_n() {
+        // Alphabetical list; "zoom" was launched recently but sorts last.
+        let apps = plain_apps(&["alpha", "beta", "gamma", "zoom"]);
+        let mut history = HashMap::new();
+        history.insert("zoom".to_string(), 1000);
+
+        let indices = initial_indices(&apps, &history, 2);
+        assert_eq!(indices, vec![3, 0]);
+    }
+
+    #[test]
+    fn initial_indices_keeps_favorites_on_top() {
+        let mut apps = plain_apps(&["fav", "other", "recent"]);
+        apps[0].favorite = true;
+        let mut history = HashMap::new();
+        history.insert("recent".to_string(), 1000);
+
+        let indices = initial_indices(&apps, &history, 2);
+        assert_eq!(indices, vec![0, 2]);
+    }
+
+    #[test]
+    fn initial_indices_preserves_order_without_history() {
+        let apps = plain_apps(&["a", "b", "c"]);
+        let indices = initial_indices(&apps, &HashMap::new(), 2);
+        assert_eq!(indices, vec![0, 1]);
+    }
 }


### PR DESCRIPTION
## What

Audit fixes from a performance/best-practices review pass:

- **CI was red**: fixes 4 new clippy `unnecessary_sort_by` errors in `history.rs` (clippy 1.95)
- **Ranking bug**: the empty-query list took the first `initial_results` apps alphabetically and only then sorted by recency, so a recently launched app sorting outside the first N never appeared. Now all apps sort by (favorite, recency) before truncating — favorites stay pinned. Unit-tested.
- **Locale**: desktop entry names/descriptions/keywords now use `get_languages_from_env()` instead of hardcoded `"en"`
- **Single instance footgun**: GApplication uniqueness meant relaunching yeet while open fired `activate` on the first process and stacked a second window inside it. Now `NON_UNIQUE`.
- **Dead code**: removes crate-wide `#![allow(dead_code)]` and what it hid — `App.exec`, `App::search_text()`, and the never-wired `general.monitor` config (serde ignores unknown keys, existing configs still parse)
- Perf nit: `sort_by_cached_key` for the app sort (was allocating two lowercase strings per comparison)

## Config/default changes

`general.monitor` removed from `defaults/config.toml` and README — it was parsed but never read.
