### PR TITLE
feat: stdin/dmenu mode (yeet --dmenu)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- dmenu mode: `yeet --dmenu` reads items from stdin, prints the selection to stdout, and exits non-zero when nothing is selected (#9)
+- `--help` / `--version` flags
 - Scrollable result list; `initial_results = 0` now shows all apps in a scrollable list (#7)
 - Desktop entry names, descriptions, and keywords now honor the system locale instead of always using English
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ yeet
 
 Bind it to a key in your compositor (e.g., `Super+Space` in Hyprland/Sway).
 
+### dmenu mode
+
+Pipe lines into `yeet --dmenu` and the selection is printed to stdout, so yeet can drive script menus the same way `wofi --dmenu` or `rofi -dmenu` do:
+
+```sh
+# Simple picker
+selected=$(echo -e "Firefox\nChrome\nBrave" | yeet --dmenu)
+
+# Keybind viewer
+grep "^bind" ~/.config/hypr/hyprland.conf | yeet --dmenu
+```
+
+Exits non-zero when nothing is selected (Escape).
+
 ## Configuration
 
 Config lives in `~/.config/yeet/`. Yeet ships with sensible defaults — only override what you need.

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -35,8 +35,7 @@ impl App {
         }
     }
 
-    /// A bare item with a name only; used in tests.
-    #[cfg(test)]
+    /// A bare item with a name only; used for dmenu mode and tests.
     pub fn plain(name: String) -> Self {
         Self {
             launch: LaunchCommand::Shell(name.clone()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,29 +4,114 @@ mod history;
 mod ui;
 
 use config::Config;
-use desktop::discover_apps;
+use desktop::{discover_apps, launch_app, App};
 use gtk4::gio::ApplicationFlags;
 use gtk4::prelude::*;
 use gtk4::Application;
+use std::cell::Cell;
+use std::io::BufRead;
+use std::rc::Rc;
 
 const APP_ID: &str = "dev.yeet.launcher";
 
 fn main() {
+    let mut dmenu = false;
+    for arg in std::env::args().skip(1) {
+        match arg.as_str() {
+            "-d" | "--dmenu" => dmenu = true,
+            "-h" | "--help" => {
+                print_help();
+                return;
+            }
+            "-V" | "--version" => {
+                println!("yeet {}", env!("CARGO_PKG_VERSION"));
+                return;
+            }
+            other => {
+                eprintln!("yeet: unknown option '{other}' (see --help)");
+                std::process::exit(2);
+            }
+        }
+    }
+
     let config = Config::load();
 
-    let apps = discover_apps(&config);
+    if dmenu {
+        run_dmenu(config);
+    } else {
+        run_launcher(config);
+    }
+}
 
-    // NON_UNIQUE: launching yeet while a window is already open gets its own
-    // instance instead of stacking a second window inside the first one.
-    let app = Application::builder()
+fn print_help() {
+    println!(
+        "yeet {} - a fast, minimal app launcher for Wayland
+
+Usage: yeet [OPTIONS]
+
+Options:
+  -d, --dmenu    read items from stdin, print the selection to stdout
+  -h, --help     print this help
+  -V, --version  print version",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+fn gtk_app() -> Application {
+    // NON_UNIQUE: each invocation gets its own window and, in dmenu mode,
+    // its own stdin/stdout instead of activating an existing instance.
+    Application::builder()
         .application_id(APP_ID)
         .flags(ApplicationFlags::NON_UNIQUE)
-        .build();
+        .build()
+}
+
+fn run_launcher(config: Config) {
+    let apps = discover_apps(&config);
+    let app = gtk_app();
 
     app.connect_activate(move |app| {
-        ui::build_ui(app, &config, apps.clone());
+        let terminal = config.general.terminal.clone();
+        let on_select: Rc<dyn Fn(&App)> = Rc::new(move |app| launch_app(app, &terminal));
+        ui::build_ui(app, &config, apps.clone(), on_select);
     });
 
     // we don't use GTK's arg parsing
     app.run_with_args::<&str>(&[]);
+}
+
+fn run_dmenu(mut config: Config) {
+    // dmenu items are arbitrary lines: show all of them up front and keep
+    // launch history out of both ranking and recording.
+    config.general.initial_results = 0;
+    config.search.use_history = false;
+
+    let items: Vec<App> = std::io::stdin()
+        .lock()
+        .lines()
+        .map_while(Result::ok)
+        .filter(|line| !line.is_empty())
+        .map(App::plain)
+        .collect();
+
+    if items.is_empty() {
+        eprintln!("yeet: --dmenu expects items on stdin");
+        std::process::exit(1);
+    }
+
+    let selected = Rc::new(Cell::new(false));
+    let app = gtk_app();
+
+    let selected_flag = selected.clone();
+    app.connect_activate(move |app| {
+        let selected_flag = selected_flag.clone();
+        let on_select: Rc<dyn Fn(&App)> = Rc::new(move |item| {
+            println!("{}", item.name);
+            selected_flag.set(true);
+        });
+        ui::build_ui(app, &config, items.clone(), on_select);
+    });
+
+    app.run_with_args::<&str>(&[]);
+    std::process::exit(if selected.get() { 0 } else { 1 });
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::desktop::{launch_app, App};
+use crate::desktop::App;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
 use gtk4::gdk::{Display, ModifierType};
@@ -16,7 +16,7 @@ use std::rc::Rc;
 
 const DEFAULT_STYLE: &str = include_str!("../defaults/style.css");
 
-pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>) {
+pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>, on_select: Rc<dyn Fn(&App)>) {
     load_css();
 
     let window = ApplicationWindow::builder()
@@ -88,7 +88,6 @@ pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>) {
     let min_score = config.search.min_score;
     let score_threshold = config.search.score_threshold;
     let prefer_prefix = config.search.prefer_prefix;
-    let terminal = config.general.terminal.clone();
     let show_shortcuts = config.appearance.show_shortcuts;
     let show_descriptions = config.appearance.show_descriptions;
     let use_history = config.search.use_history;
@@ -209,21 +208,28 @@ pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>) {
         });
     }
 
+    let activate_selection = {
+        let apps = apps.clone();
+        let filtered_apps = filtered_apps.clone();
+        let window = window.clone();
+        let on_select = on_select.clone();
+
+        Rc::new(move |row_idx: usize| {
+            let app_idx = filtered_apps.borrow().get(row_idx).copied();
+            if let Some(app_idx) = app_idx {
+                on_select(&apps[app_idx]);
+                window.close();
+            }
+        })
+    };
+
     {
-        let list_box_enter = list_box.clone();
-        let apps_enter = apps.clone();
-        let filtered_enter = filtered_apps.clone();
-        let window_enter = window.clone();
-        let terminal_enter = terminal.clone();
+        let list_box = list_box.clone();
+        let activate = activate_selection.clone();
 
         entry.connect_activate(move |_| {
-            if let Some(row) = list_box_enter.selected_row() {
-                let idx = row.index() as usize;
-                let filtered = filtered_enter.borrow();
-                if let Some(&app_idx) = filtered.get(idx) {
-                    launch_app(&apps_enter[app_idx], &terminal_enter);
-                    window_enter.close();
-                }
+            if let Some(row) = list_box.selected_row() {
+                activate(row.index() as usize);
             }
         });
     }
@@ -231,9 +237,7 @@ pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>) {
     {
         let list_box_nav = list_box.clone();
         let window_close = window.clone();
-        let apps_shortcut = apps.clone();
-        let filtered_shortcut = filtered_apps.clone();
-        let terminal_shortcut = terminal.clone();
+        let activate = activate_selection.clone();
 
         let scroll_controller =
             gtk4::EventControllerScroll::new(gtk4::EventControllerScrollFlags::VERTICAL);
@@ -287,12 +291,8 @@ pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>) {
                 };
 
                 if let Some(idx) = num {
-                    let filtered = filtered_shortcut.borrow();
-                    if let Some(&app_idx) = filtered.get(idx) {
-                        launch_app(&apps_shortcut[app_idx], &terminal_shortcut);
-                        window_close.close();
-                        return gtk4::glib::Propagation::Stop;
-                    }
+                    activate(idx);
+                    return gtk4::glib::Propagation::Stop;
                 }
             }
 
@@ -321,17 +321,9 @@ pub fn build_ui(app: &Application, config: &Config, apps: Vec<App>) {
     }
 
     {
-        let apps_click = apps.clone();
-        let filtered_click = filtered_apps.clone();
-        let window_click = window.clone();
-
+        let activate = activate_selection.clone();
         list_box.connect_row_activated(move |_, row| {
-            let idx = row.index() as usize;
-            let filtered = filtered_click.borrow();
-            if let Some(&app_idx) = filtered.get(idx) {
-                launch_app(&apps_click[app_idx], &terminal);
-                window_click.close();
-            }
+            activate(row.index() as usize);
         });
     }
 


### PR DESCRIPTION
## What

`yeet --dmenu` reads lines from stdin, shows them in the normal search UI, prints the selection to stdout, and exits:
- `0` — a line was selected
- `1` — Escape / nothing selected / empty stdin
- `2` — unknown flag

```sh
selected=$(echo -e "Firefox\nChrome\nBrave" | yeet --dmenu)
grep "^bind" ~/.config/hypr/hyprland.conf | yeet --dmenu
```

## How

- `build_ui` now takes an `on_select` callback — launcher mode launches, dmenu mode prints. Enter, Alt+N, and click all share one activation path.
- dmenu shows all stdin items up front (rides the scrollable list from #7) and keeps history out of both ranking and recording
- Hand-rolled arg parsing (three flags don't justify clap); `--help`/`--version` included
- `NON_UNIQUE` GApplication (from the audit PR) is what makes running `--dmenu` while the launcher is open possible at all

Closes #9